### PR TITLE
Update output vars

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,12 +1,12 @@
 locals {
-  this_id                           = compact(coalescelist(aws_instance.this.*.id, [""]))
+  this_id                           = aws_instance.this.*.id
   this_availability_zone            = compact(coalescelist(aws_instance.this.*.availability_zone, [""]))
   this_key_name                     = compact(coalescelist(aws_instance.this.*.key_name, [""]))
   this_public_dns                   = compact(coalescelist(aws_instance.this.*.public_dns, [""]))
   this_public_ip                    = compact(coalescelist(aws_instance.this.*.public_ip, [""]))
   this_primary_network_interface_id = compact(coalescelist(aws_instance.this.*.primary_network_interface_id, [""]))
   this_private_dns                  = compact(coalescelist(aws_instance.this.*.private_dns, [""]))
-  this_private_ip                   = compact(coalescelist(aws_instance.this.*.private_ip, [""]))
+  this_private_ip                   = aws_instance.this.*.private_ip
   this_placement_group              = compact(coalescelist(aws_instance.this.*.placement_group, [""]))
   this_security_groups              = coalescelist(aws_instance.this.*.security_groups, [""])
   this_vpc_security_group_ids       = coalescelist(flatten(aws_instance.this.*.vpc_security_group_ids), [""])

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,20 +1,20 @@
 locals {
   this_id                           = aws_instance.this.*.id
-  this_availability_zone            = compact(coalescelist(aws_instance.this.*.availability_zone, [""]))
-  this_key_name                     = compact(coalescelist(aws_instance.this.*.key_name, [""]))
-  this_public_dns                   = compact(coalescelist(aws_instance.this.*.public_dns, [""]))
-  this_public_ip                    = compact(coalescelist(aws_instance.this.*.public_ip, [""]))
-  this_primary_network_interface_id = compact(coalescelist(aws_instance.this.*.primary_network_interface_id, [""]))
-  this_private_dns                  = compact(coalescelist(aws_instance.this.*.private_dns, [""]))
+  this_availability_zone            = aws_instance.this.*.availability_zone
+  this_key_name                     = aws_instance.this.*.key_name
+  this_public_dns                   = aws_instance.this.*.public_dns
+  this_public_ip                    = aws_instance.this.*.public_ip
+  this_primary_network_interface_id = aws_instance.this.*.primary_network_interface_id
+  this_private_dns                  = aws_instance.this.*.private_dns
   this_private_ip                   = aws_instance.this.*.private_ip
-  this_placement_group              = compact(coalescelist(aws_instance.this.*.placement_group, [""]))
-  this_security_groups              = coalescelist(aws_instance.this.*.security_groups, [""])
-  this_vpc_security_group_ids       = coalescelist(flatten(aws_instance.this.*.vpc_security_group_ids), [""])
-  this_subnet_id                    = compact(coalescelist(aws_instance.this.*.subnet_id, [""]))
-  this_credit_specification         = flatten(aws_instance.this.*.credit_specification)
-  this_tags                         = coalescelist(aws_instance.this.*.tags, [""])
-  this_volume_tags                  = coalescelist(aws_instance.this.*.volume_tags, [""])
-  this_password_data                = coalescelist(aws_instance.this.*.password_data, [""])
+  this_placement_group              = aws_instance.this.*.placement_group
+  this_security_groups              = aws_instance.this.*.security_groups
+  this_vpc_security_group_ids       = aws_instance.this.*.vpc_security_group_ids
+  this_subnet_id                    = aws_instance.this.*.subnet_id
+  this_credit_specification         = aws_instance.this.*.credit_specification
+  this_tags                         = aws_instance.this.*.tags
+  this_volume_tags                  = aws_instance.this.*.volume_tags
+  this_password_data                = aws_instance.this.*.password_data
 }
 
 output "id" {


### PR DESCRIPTION
This PR removed the function calls that wrapped in the outputs. This fixes the provisioning step so that only new or replaced nodes are flagged for provisioning.  